### PR TITLE
⭐️ set new default for `force_registration` to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The role is published at Ansible Galaxy: [Mondoo role](https://galaxy.ansible.co
 | -------------- | ------------- | -----------------------------------|
 | `registration_token_retrieval` | `manual` | `manual` requires to set ``registration_token`. `cli` call a local Mondoo Client to automatically retrieve a new registration token |
 | `registration_token`|  n/a | manually set the Mondoo Registration Token that is used to register new Mondoo Clients
-| `force_registration`|  true | forces re-registration for each run
+| `force_registration`|  false | forces re-registration for each run
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@
 latest_version_url: https://releases.mondoo.io/mondoo/latest.json
 
 # option to force a re-registration
-force_registration: true
+force_registration: false
 
 # we support 'manual' and 'cli'
 # if 'manual' is set, the user need to set `registration_token`


### PR DESCRIPTION
Previously we set the default for `force_registration` to true, which is annoying if you just want to update all clients but not re-registering them. This changes the default to `false`.

```yaml
---
- hosts: mondoo_linux
  become: yes
  roles:
    - role: mondoolabs.mondoo
      vars:
        registration_token: "changeme"
        force_registration: false
        ensure_managed_client: true
```

Signed-off-by: Christoph Hartmann <chris@lollyrock.com>